### PR TITLE
Add LOCAL=logon and extra docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ $da = [System.Security.Principal.NTAccount]'DOMAIN\Domain Admins'
 ConvertTo-DpapiNGSecret MySecret -Sid $da
 ```
 
+The `-CurrentSid` and `-Sid` options can be used on domain joined hosts to protect a secret for that domain user/group specified.
+This secret can be decrypted by that user or member of the group specified on any domain joined host.
+
 To decrypt the DPAPI-NG blob back:
 
 ```powershell

--- a/docs/en-US/Add-DpapiNGDescriptor.md
+++ b/docs/en-US/Add-DpapiNGDescriptor.md
@@ -37,9 +37,10 @@ The following descriptor types are supported:
 
 + `SID`
 
-The `LOCAL` type can be scoped to just the current user locally or to the local machine.
-The `SID` type can be scoped to a user or group SecurityIdentifier.
+The `LOCAL` type can be scoped to just the current user, current logon session, or to the local machine.
+The `SID` type can be scoped to a domain user or domain group SecurityIdentifier.
 This protection is applied across the domain allowing a user with this SID to be able to decrypt the secret on any machine.
+To use the `SID` protection descriptor the host must be joined to a domain with the forest level of 2012 or newer.
 
 ## EXAMPLES
 
@@ -79,6 +80,8 @@ Creates a DPAPI-NG secret that is protected by the current user when a `Domain A
 Adds the clause `SID=$UserSid` where `$UserSid` represents the current user's SecurityIdentifier.
 A secret protected by this value can be decrypted by this user on any machine in the domain.
 
+Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: SidCurrent
@@ -107,9 +110,11 @@ Accept wildcard characters: False
 ```
 
 ### -Local
-Adds the `LOCAL` descriptor clause to either `User` or `Machine`.
+Adds the `LOCAL` descriptor clause to either `User`, `Machine`, `Logon`.
 The `User` value protects the secret to just this user on the current host.
 The `Machine` value protects the secret to the current computer.
+The `Logon` value protects the secret to just this user's logon session.
+This is slightly different to `User` in that the same user logged on through another session will be unable to decrypt the secret.
 
 ```yaml
 Type: String
@@ -144,6 +149,8 @@ Accept wildcard characters: False
 Adds the `SID` descriptor clause to the SecurityIdentifier specified.
 The SecurityIdentifier can be the SID of a domain user or group.
 If a group SID is specified, any user who is a member of that group can decrypt the secret it applies to.
+
+Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
 
 ```yaml
 Type: StringOrAccount

--- a/docs/en-US/ConvertTo-DpapiNGSecret.md
+++ b/docs/en-US/ConvertTo-DpapiNGSecret.md
@@ -94,6 +94,8 @@ Protects the secret with the current domain user's identity.
 The encrypted secret can be decrypted by this user on any other host in the domain.
 This is the equivalent of doing `-ProtectionDescriptor "SID=$([System.Security.Principal.WindowsIdentity]::GetCurrent().User)"`.
 
+Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: SidCurrent
@@ -167,9 +169,11 @@ Accept wildcard characters: False
 ```
 
 ### -Local
-Protects the secret using the `LOCAL=machine` or `LOCAL=user` protection descriptor.
+Protects the secret using the `LOCAL=machine`, `LOCAL=user`, or `LOCAL=logon` protection descriptor.
 The `User` value protects the secret to just this user on the current host and is the default value.
 The `Machine` value protects the secret to the current computer.
+The `Logon` value protects the secret to just this user's logon session.
+This is slightly different to `User` in that the same user logged on through another session will be unable to decrypt the secret.
 
 ```yaml
 Type: String
@@ -201,9 +205,11 @@ Accept wildcard characters: False
 ```
 
 ### -Sid
-Allows only the user or group specified by this SID to be able to decrypt the DPAPI-NG secret.
+Allows only the domain user or domain group specified by this SID to be able to decrypt the DPAPI-NG secret.
 If a group SID is specified, any user who is a member of that group can decrypt the secret it applies to.
 The value can either by a SecurityIdentifier string in the format `S-1-...` or as a [System.Security.Principal.NTAccount](https://learn.microsoft.com/en-us/dotnet/api/system.security.principal.ntaccount?view=net-8.0) object which will automatically be translated to a SID.
+
+Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
 
 ```yaml
 Type: StringOrAccount

--- a/src/SecretManagement.DpapiNG.Module/ConvertToDpapiNGSecret.cs
+++ b/src/SecretManagement.DpapiNG.Module/ConvertToDpapiNGSecret.cs
@@ -49,7 +49,7 @@ public sealed class ConvertToDpapiNGCommand : PSCmdlet
         Position = 1,
         ParameterSetName = "Local"
     )]
-    [ValidateSet("Machine", "User")]
+    [ValidateSet("Logon", "Machine", "User")]
     public string Local { get; set; } = "User";
 
     [Parameter(

--- a/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptor.cs
+++ b/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptor.cs
@@ -69,7 +69,7 @@ public class AddDpapiNGDescriptorCommand : PSCmdlet
         Mandatory = true,
         ParameterSetName = "Local"
     )]
-    [ValidateSet("User", "Machine")]
+    [ValidateSet("Logon", "Machine", "User")]
     public string Local { get; set; } = "User";
 
     [Parameter(


### PR DESCRIPTION
Adds support for the LOCAL=logon protection string and expand the docs for the SID types to mention they only work in domain environments.