### PR TITLE
Add default path and certificate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.2.0 - TBD
 
++ Use a default vault path when registering a vault without a path
+  + The path will be `$env:LOCALAPPDATA\SecretManagement.DpapiNG\default.vault`
++ Add support for `-Certificate` and `-CertificateThumbprint` when specifying a DPAPI-NG protection descriptor
+
 ## v0.1.0 - 2023-11-21
 
 + Initial version of the `SecretManagement.DpapiNG` module

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ See [ConvertTo-DpapiNGSecret](./docs/en-US/ConvertTo-DpapiNGSecret.md) and [Conv
 To register a DPAPI-NG vault for use with `SecretManagement`:
 
 ```powershell
+# Registers a DPAPI-NG vault with the default path in the user profile.
+Register-SecretVault -Name DpapiNG -ModuleName SecretManagement.DpapiNG
+
+# Registers a DPAPI-NG vault with a custom vault path.
 $vaultParams = @{
     Name = 'MyVault'
     ModuleName = 'SecretManagement.DpapiNG'
@@ -61,7 +65,7 @@ $vaultParams = @{
 Register-SecretVault @vaultParams
 ```
 
-The vault `MyVault` can now be used with [Set-Secret](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/set-secret?view=ps-modules) and [Get-Secret](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/get-secret?view=ps-modules) to get and set secrets using DPAPI-NG.
+The vault name that was registered can now be used with [Set-Secret](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/set-secret?view=ps-modules) and [Get-Secret](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/get-secret?view=ps-modules) to get and set secrets using DPAPI-NG.
 
 ```powershell
 # Uses the default protection of 'LOCAL=user'
@@ -87,17 +91,20 @@ See [about_DpapiNGSecretManagement](./docs/en-US/about_DpapiNGSecretManagement.m
 
 The easiest way to install this module is through [PowerShellGet](https://docs.microsoft.com/en-us/powershell/gallery/overview).
 
-You can install this module by running;
+You can install this module by running either of the following `Install-PSResource` or `Install-Module` command.
 
 ```powershell
 # Install for only the current user
+Install-PSResource -Name SecretManagement.DpapiNG, Microsoft.PowerShell.SecretManagement -Scope CurrentUser
 Install-Module -Name SecretManagement.DpapiNG, Microsoft.PowerShell.SecretManagement -Scope CurrentUser
 
 # Install for all users
+Install-PSResource -Name SecretManagement.DpapiNG, Microsoft.PowerShell.SecretManagement -Scope AllUsers
 Install-Module -Name SecretManagement.DpapiNG, Microsoft.PowerShell.SecretManagement -Scope AllUsers
 ```
 
 If the `SecretManagement` implementation is not needed, the `Microsoft.PowerShell.SecretManagement` package can be omitted during the install.
+The `Install-PSResource` cmdlet is part of the new `PSResourceGet` module from Microsoft available in newer versions while `Install-Module` is present on older systems.
 
 ## Contributing
 

--- a/docs/en-US/Add-DpapiNGDescriptor.md
+++ b/docs/en-US/Add-DpapiNGDescriptor.md
@@ -14,17 +14,29 @@ Adds a new protection descriptor clause.
 
 ### Local (Default)
 ```
-Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> -Local <String> [-Or] [<CommonParameters>]
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] [-Local <String>] [<CommonParameters>]
 ```
 
 ### Sid
 ```
-Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> -Sid <StringOrAccount> [-Or] [<CommonParameters>]
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] -Sid <StringOrAccount> [<CommonParameters>]
 ```
 
 ### SidCurrent
 ```
-Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-CurrentSid] [-Or] [<CommonParameters>]
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] [-CurrentSid] [<CommonParameters>]
+```
+
+### Certificate
+```
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] -Certificate <X509Certificate2>
+ [<CommonParameters>]
+```
+
+### CertificateThumbprint
+```
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] -CertificateThumbprint <String>
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,10 +49,15 @@ The following descriptor types are supported:
 
 + `SID`
 
++ `CERTIFICATE`
+
 The `LOCAL` type can be scoped to just the current user, current logon session, or to the local machine.
 The `SID` type can be scoped to a domain user or domain group SecurityIdentifier.
 This protection is applied across the domain allowing a user with this SID to be able to decrypt the secret on any machine.
 To use the `SID` protection descriptor the host must be joined to a domain with the forest level of 2012 or newer.
+The `CERTIFICATE` type is scoped to the specified certificate used to encrypt and decrypt the data.
+The encryption process uses the certificate public key specified while the decryption process requires the associated private key.
+If specifying a certificate by a thumbprint the certificate must be in the `Cert:\CurrentUser\My` certificate store.
 
 ## EXAMPLES
 
@@ -75,6 +92,40 @@ PS C:\> ConvertTo-DpapiNGSecret secret -ProtectionDescriptor $desc
 Creates a DPAPI-NG secret that is protected by the current user when a `Domain Admins` member.
 
 ## PARAMETERS
+
+### -Certificate
+The `X509Certificate2` to use when encrypting the data.
+The decryptor needs to have the associated private key of the certificate used to decrypt the value.
+This method will set the protection descriptor `CERTIFICATE=CertBlob:$certBase64String`.
+
+```yaml
+Type: X509Certificate2
+Parameter Sets: Certificate
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CertificateThumbprint
+The thumbprint for a certificate stored inside `Cert:\CurrentUser\My` to use for encryption.
+Only the public key needs to be present to encrypt the value but the decryption process requires the associated private key to be present.
+This method will set the protection descriptor `CERTIFICATE=HashID:$CertificateThumbprint`.
+
+```yaml
+Type: String
+Parameter Sets: CertificateThumbprint
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -CurrentSid
 Adds the clause `SID=$UserSid` where `$UserSid` represents the current user's SecurityIdentifier.
@@ -122,7 +173,7 @@ Parameter Sets: Local
 Aliases:
 Accepted values: User, Machine
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/en-US/ConvertTo-DpapiNGSecret.md
+++ b/docs/en-US/ConvertTo-DpapiNGSecret.md
@@ -14,8 +14,8 @@ Encrypts data as a DPAPI-NG secret.
 
 ### Local (Default)
 ```
-ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Local <String>]
- [-Encoding <Encoding>] [<CommonParameters>]
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>]
+ [-Local <String>] [<CommonParameters>]
 ```
 
 ### ProtectionDescriptor
@@ -26,14 +26,26 @@ ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]>
 
 ### Sid
 ```
-ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Sid <StringOrAccount>]
- [-Encoding <Encoding>] [<CommonParameters>]
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>]
+ -Sid <StringOrAccount> [<CommonParameters>]
 ```
 
 ### SidCurrent
 ```
-ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-CurrentSid] [-Encoding <Encoding>]
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>] [-CurrentSid]
  [<CommonParameters>]
+```
+
+### Certificate
+```
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>]
+ -Certificate <X509Certificate2> [<CommonParameters>]
+```
+
+### CertificateThumbprint
+```
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>]
+ -CertificateThumbprint <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -41,8 +53,9 @@ Encrypts the input data into a base64 encoded string.
 The encrypted data is protected using the protection descriptor specified.
 Use [ConvertFrom-DpapiNGSecret](./ConvertFrom-DpapiNGSecret.md) to decrypt the secret data back into a usable object.
 By default the secret will be protected with the `LOCAL=user` protection descriptor which only allows the current user on the current host the ability to decrypt the secret.
-The `-Sid` or `-CurrentSid` parameter can be used to specify a specific domain user/group or the current domain user the ability to decrypt the secret.
+The `-Sid` or `-CurrentSid` parameters can be used to specify a specific domain user/group or the current domain user the ability to decrypt the secret.
 The [New-DpapiNGDescriptor](./New-DpapiNGDescriptor.md) and [Add-DpapiNGDescriptor](./Add-DpapiNGDescriptor.md) to build a more complex protection descriptor used to protect the secret.
+The `-Certificate` or `-CertificateThumbprint` parameters can be used to specify a certificate that can encrypt and decrypt the secret using the certificate specified.
 
 ## EXAMPLES
 
@@ -89,6 +102,40 @@ It is also possible to provide a string to `-ProtectionDescriptor` if crafting i
 
 ## PARAMETERS
 
+### -Certificate
+The `X509Certificate2` to use when encrypting the data.
+The decryptor needs to have the associated private key of the certificate used to decrypt the value.
+This method will set the protection descriptor `CERTIFICATE=CertBlob:$certBase64String`.
+
+```yaml
+Type: X509Certificate2
+Parameter Sets: Certificate
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CertificateThumbprint
+The thumbprint for a certificate stored inside `Cert:\CurrentUser\My` to use for encryption.
+Only the public key needs to be present to encrypt the value but the decryption process requires the associated private key to be present.
+This method will set the protection descriptor `CERTIFICATE=HashID:$CertificateThumbprint`.
+
+```yaml
+Type: String
+Parameter Sets: CertificateThumbprint
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -CurrentSid
 Protects the secret with the current domain user's identity.
 The encrypted secret can be decrypted by this user on any other host in the domain.
@@ -101,7 +148,7 @@ Type: SwitchParameter
 Parameter Sets: SidCurrent
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -216,7 +263,7 @@ Type: StringOrAccount
 Parameter Sets: Sid
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/en-US/about_DpapiNGSecretManagement.md
+++ b/docs/en-US/about_DpapiNGSecretManagement.md
@@ -7,9 +7,23 @@ This guide will demonstrate how to register a DPAPI-NG vault and interact with i
 It is also possible to use the [ConvertTo-DpapiNGSecret](./ConvertTo-DpapiNGSecret.md) and [ConvertFrom-DpapiNGSecret](./ConvertFrom-DpapiNGSecret.md) cmdlets to encrypt and decrypt DPAPI-NG values manually without integration with a `SecretManagement` vault.
 
 # LONG DESCRIPTION
-The first step to using this with `SecretManagement` is to register a DPAPI-NG vault to interact with using [Register-SecretVault](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/register-secretvault?view=ps-modules).
+The `SecretManagement` integration will only work if the [Microsoft.PowerShell.SecretManagement](https://www.powershellgallery.com/packages/Microsoft.PowerShell.SecretManagement/) has been installed.
 
 ```powershell
+# Using the new PSResourceGet module
+Install-PSResource -Name Microsoft.PowerShell.SecretManagement
+
+# Using the old PowerShellGet module
+Install-Module -Name Microsoft.PowerShell.SecretManagement
+```
+
+Once installed the next step is to register a DPAPI-NG vault to interact with using [Register-SecretVault](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/register-secretvault?view=ps-modules).
+
+```powershell
+# Registers a DPAPI-NG vault with the default path in the user profile.
+Register-SecretVault -Name MyVault -ModuleName SecretManagement.DpapiNG
+
+# Registers a DPAPI-NG vault with a custom vault path
 $vaultParams = @{
     Name = 'MyVault'
     ModuleName = 'SecretManagement.DpapiNG'
@@ -20,8 +34,8 @@ $vaultParams = @{
 Register-SecretVault @vaultParams
 ```
 
-This cmdlet will create a DPAPI-NG vault called `MyVault` that stores the secrets at `C:\path\to\vault_file`.
-The vault file at `Path` will be automatically created when the first secret is stored.
+This cmdlet will create a DPAPI-NG vault called `MyVault`, if no `Path` was specified in the `VaultParameters` a default path under `$env:LOCALAPPDATA\SecretManagement.DpapiNG\default.vault` is used as the path.
+If the vault file specified does not exist it will automatically be created when the vault operation is performed.
 It must be a the path to a file and the parent directory must already exist.
 Once the vault is registered it can referenced by the `-VaultName MyVault` parameter on the other `SecretManagement` cmdlets.
 It is possible to copy the vault file directory to other hosts as long as the secrets it contains is protected in a way that isn't tied to the same host.

--- a/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptorBase.cs
+++ b/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptorBase.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Management.Automation;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+
+public abstract class DpapiNGDescriptorBase : PSCmdlet
+{
+    internal const string DEFAULT_PARAM_SET = "Local";
+
+    [Parameter(
+        ParameterSetName = "Local"
+    )]
+    [ValidateSet("Logon", "Machine", "User")]
+    public string Local { get; set; } = "User";
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "Sid"
+    )]
+    public StringOrAccount Sid { get; set; } = default!;
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "SidCurrent"
+    )]
+    public SwitchParameter CurrentSid { get; set; }
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "Certificate"
+    )]
+    public X509Certificate2? Certificate { get; set; }
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "CertificateThumbprint"
+    )]
+    public string? CertificateThumbprint { get; set; }
+
+    internal string GetRuleString() => ParameterSetName switch
+    {
+        "Local" => $"LOCAL={Local.ToLowerInvariant()}",
+        "Sid" => $"SID={Sid.Value}",
+#pragma warning disable CA1416
+#pragma warning disable CS8602
+        "SidCurrent" => $"SID={WindowsIdentity.GetCurrent().User.Value}",
+#pragma warning restore CA1416
+#pragma warning restore CS8602
+        "Certificate" => $"CERTIFICATE=CertBlob:{Convert.ToBase64String(Certificate!.Export(X509ContentType.Cert))}",
+        "CertificateThumbprint" => $"CERTIFICATE=HashId:{CertificateThumbprint!}",
+        _ => throw new NotImplementedException(),
+    };
+}

--- a/src/SecretManagement.DpapiNG.Module/DpapiNGSecretBase.cs
+++ b/src/SecretManagement.DpapiNG.Module/DpapiNGSecretBase.cs
@@ -15,23 +15,25 @@ public abstract class DpapiNGSecretBase : PSCmdlet
 
     protected override void ProcessRecord()
     {
+        string vaultPath;
         if (
-            !AdditionalParameters.ContainsKey("Path") ||
-            !(AdditionalParameters["Path"] is string vaultPath) ||
-            string.IsNullOrWhiteSpace(vaultPath)
+            AdditionalParameters.ContainsKey("Path") &&
+            AdditionalParameters["Path"] is string tempVaultPath &&
+            !string.IsNullOrWhiteSpace(tempVaultPath)
         )
         {
-            string msg =
-                "Invalid SecretManagement.DpapiNG vault registration: AdditionalParameters must contain a Path " +
-                "string.";
-            ErrorRecord err = new(
-                new ArgumentException(msg),
-                "SecretManagement.DpapiNG.NoPathParams",
-                ErrorCategory.InvalidArgument,
-                null
-            );
-            WriteError(err);
-            return;
+            vaultPath = tempVaultPath;
+        }
+        else
+        {
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string secretManagementDir = Path.Combine(localAppData, "SecretManagement.DpapiNG");
+            if (!Directory.Exists(secretManagementDir))
+            {
+                Directory.CreateDirectory(secretManagementDir);
+            }
+
+            vaultPath = Path.Combine(secretManagementDir, "default.vault");
         }
 
         string providerPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(


### PR DESCRIPTION
Use a default path for the DPAPI-NG vault registration if no path was specified. Also adds explicit support for certificate encryption through the -Certificate or -CertificateThumbprint parameters when declaring a protection descriptor.