### PR TITLE
Add WebCredential support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.3.0 - TBD
 
++ Add support for `-WebCredential` when specifying a DPAPI-NG protection descriptor
+
 ## v0.2.0 - 2023-11-21
 
 + Use a default vault path when registering a vault without a path

--- a/docs/en-US/Add-DpapiNGDescriptor.md
+++ b/docs/en-US/Add-DpapiNGDescriptor.md
@@ -39,6 +39,11 @@ Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] -CertificateThum
  [<CommonParameters>]
 ```
 
+### WebCredential
+```
+Add-DpapiNGDescriptor -InputObject <ProtectionDescriptor> [-Or] -WebCredential <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Adds a new protection descriptor clause to an existing protection descriptor created by [New-DpapiNGDescriptor](./New-DpapiNGDescriptor.md).
 Each new clause will be added with an `AND` unless `-Or` is specified.
@@ -50,6 +55,8 @@ The following descriptor types are supported:
 + `SID`
 
 + `CERTIFICATE`
+
++ `WEBCREDENTIALS`
 
 See [about_DpapiNGProtectionDescriptor](./about_DpapiNGProtectionDescriptor.md) for more details.
 
@@ -200,6 +207,22 @@ Using a `SID` protection descriptor requires the host to be joined to a domain w
 ```yaml
 Type: StringOrAccount
 Parameter Sets: Sid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WebCredential
+The credential manager to protect the secret with.
+The string value is in the format `username,resource`, for example a web credential for `dpapi-ng.com` with the user `MyUser` would be `-WebCredential 'MyUser,dpapi-ng.com'`.
+
+```yaml
+Type: String
+Parameter Sets: WebCredential
 Aliases:
 
 Required: True

--- a/docs/en-US/ConvertTo-DpapiNGSecret.md
+++ b/docs/en-US/ConvertTo-DpapiNGSecret.md
@@ -48,6 +48,12 @@ ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encod
  -CertificateThumbprint <String> [<CommonParameters>]
 ```
 
+### WebCredential
+```
+ConvertTo-DpapiNGSecret [-InputObject] <StringSecureStringOrByteArray[]> [-Encoding <Encoding>]
+ -WebCredential <String> [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Encrypts the input data into a base64 encoded string.
 The encrypted data is protected using the protection descriptor specified.
@@ -260,6 +266,22 @@ Using a `SID` protection descriptor requires the host to be joined to a domain w
 ```yaml
 Type: StringOrAccount
 Parameter Sets: Sid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WebCredential
+The credential manager to protect the secret with.
+The string value is in the format `username,resource`, for example a web credential for `dpapi-ng.com` with the user `MyUser` would be `-WebCredential 'MyUser,dpapi-ng.com'`.
+
+```yaml
+Type: String
+Parameter Sets: WebCredential
 Aliases:
 
 Required: True

--- a/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptorBase.cs
+++ b/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptorBase.cs
@@ -37,6 +37,12 @@ public abstract class DpapiNGDescriptorBase : PSCmdlet
     )]
     public string? CertificateThumbprint { get; set; }
 
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "WebCredential"
+    )]
+    public string? WebCredential { get; set; }
+
     internal string GetRuleString() => ParameterSetName switch
     {
         "Local" => $"LOCAL={Local.ToLowerInvariant()}",
@@ -48,6 +54,7 @@ public abstract class DpapiNGDescriptorBase : PSCmdlet
 #pragma warning restore CS8602
         "Certificate" => $"CERTIFICATE=CertBlob:{Convert.ToBase64String(Certificate!.Export(X509ContentType.Cert))}",
         "CertificateThumbprint" => $"CERTIFICATE=HashId:{CertificateThumbprint!}",
+        "WebCredential" => $"WEBCREDENTIALS={WebCredential}",
         _ => throw new NotImplementedException(),
     };
 }

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -35,6 +35,42 @@ catch {
     $global:SIDUnvailable = $true
 }
 
+Function global:New-WebCredential {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [string]
+        $Resource,
+
+        [Parameter(Mandatory, Position = 1)]
+        [string]
+        $UserName
+    )
+
+    $vault = [Windows.Security.Credentials.PasswordVault, Windows.Security.Credentials, ContentType = WindowsRuntime]::new()
+    $vault.Add([Windows.Security.Credentials.PasswordCredential, Windows.Security.Credentials, ContentType = WindowsRuntime]::new(
+            $Resource,
+            $UserName,
+            "ResourcePassword"
+        ))
+}
+
+Function global:Remove-WebCredential {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Resource,
+
+        [Parameter(Mandatory)]
+        [string]
+        $UserName
+    )
+
+    $vault = [Windows.Security.Credentials.PasswordVault, Windows.Security.Credentials, ContentType = WindowsRuntime]::new()
+    $vault.Remove($vault.Retrieve($Resource, $UserName))
+}
+
 if ($IsCoreCLR) {
     Function global:New-X509Certificate {
         [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]


### PR DESCRIPTION
Add a basic parameter and documentation for WEBCREDENTIALS with DPAPI-NG. This encryption method uses a saved Web Credential to encrypt the data with DPAPI-NG which is typically created by Store/UWP applications.