### PR TITLE
Update LiteDB and support concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.4.0 - TBD
 
++ Bump `LiteDB` version to `5.0.21`
++ Support concurrent operations on the same vault file using LiteDB's shared concurrency model
+
 ## v0.3.0 - 2023-11-22
 
 + Add support for `-WebCredential` when specifying a DPAPI-NG protection descriptor

--- a/src/SecretManagement.DpapiNG.Module/GetSecret.cs
+++ b/src/SecretManagement.DpapiNG.Module/GetSecret.cs
@@ -9,6 +9,8 @@ namespace SecretManagement.DpapiNG.Module;
 [Cmdlet(VerbsCommon.Get, "Secret")]
 public sealed class GetSecretCommand : DpapiNGSecretBase
 {
+    protected override bool ReadOnly => true;
+
     [Parameter]
     public string Name { get; set; } = "";
 

--- a/src/SecretManagement.DpapiNG.Module/GetSecretInfo.cs
+++ b/src/SecretManagement.DpapiNG.Module/GetSecretInfo.cs
@@ -11,6 +11,8 @@ namespace SecretManagement.DpapiNG.Module;
 [Cmdlet(VerbsCommon.Get, "SecretInfo")]
 public sealed class GetSecretInfoCommand : DpapiNGSecretBase
 {
+    protected override bool ReadOnly => true;
+
     [Parameter]
     public string Filter { get; set; } = "";
 

--- a/src/SecretManagement.DpapiNG.Module/SecretManagement.DpapiNG.Module.csproj
+++ b/src/SecretManagement.DpapiNG.Module/SecretManagement.DpapiNG.Module.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.17" />
+    <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="Microsoft.PowerShell.SecretManagement.Library" Version="0.9.1" PrivateAssets="all" />
     <ProjectReference Include="../SecretManagement.DpapiNG/SecretManagement.DpapiNG.csproj" />
   </ItemGroup>

--- a/src/SecretManagement.DpapiNG.Module/TestSecretVault.cs
+++ b/src/SecretManagement.DpapiNG.Module/TestSecretVault.cs
@@ -6,6 +6,8 @@ namespace SecretManagement.DpapiNG.Module;
 [Cmdlet(VerbsDiagnostic.Test, "SecretVault")]
 public sealed class TestSecretVaultCommand : DpapiNGSecretBase
 {
+    protected override bool ReadOnly => true;
+
     [Parameter]
     public string VaultName { get; set; } = "";
 


### PR DESCRIPTION
Upgrades the LiteDB package to the latest version and add a shared connection to the LiteDB vault to enable concurrent access across multiple processes.

Fixes: https://github.com/jborean93/SecretManagement.DpapiNG/issues/8