### PR TITLE
Support NTAccount string translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 + Bump `LiteDB` version to `5.0.21`
 + Support concurrent operations on the same vault file using LiteDB's shared concurrency model
++ Support parsing a `SecurityIdentifier` or `NTAccount` string for the `-Sid` parameter on the `Add-DpapiNGDescriptor` and `ConvertTo-DpapiNGSecret` cmdelts
 
 ## v0.3.0 - 2023-11-22
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ ConvertTo-DpapiNGSecret MySecret
 ConvertTo-DpapiNGSecret MySecret -CurrentSid
 
 # Encrypts the secret so only Domain Admins on any host can decrypt.
-$da = [System.Security.Principal.NTAccount]'DOMAIN\Domain Admins'
-ConvertTo-DpapiNGSecret MySecret -Sid $da
+ConvertTo-DpapiNGSecret MySecret -Sid 'DOMAIN\Domain Admins'
 ```
 
 The `-CurrentSid` and `-Sid` options can be used on domain joined hosts to protect a secret for that domain user/group specified.

--- a/docs/en-US/Add-DpapiNGDescriptor.md
+++ b/docs/en-US/Add-DpapiNGDescriptor.md
@@ -201,6 +201,7 @@ Accept wildcard characters: False
 Adds the `SID` descriptor clause to the SecurityIdentifier specified.
 The SecurityIdentifier can be the SID of a domain user or group.
 If a group SID is specified, any user who is a member of that group can decrypt the secret it applies to.
+The value can either by a SecurityIdentifier string in the format `S-1-...`, NTAccount string that will be translated to a `SecurityIdentifier` string, or as a [System.Security.Principal.NTAccount](https://learn.microsoft.com/en-us/dotnet/api/system.security.principal.ntaccount?view=net-8.0) object which will automatically be translated to a SID.
 
 Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
 

--- a/docs/en-US/Add-DpapiNGDescriptor.md
+++ b/docs/en-US/Add-DpapiNGDescriptor.md
@@ -83,7 +83,7 @@ This secret can be decrypted on any host in the domain running under the same us
 
 ### Example 3 - Adds multiple SIDs
 ```powershell
-PS C:\> $domainAdmins = [System.Security.Principal.NTAccount]'DOMAIN\Domain Admins'
+PS C:\> $domainAdmins = 'DOMAIN\Domain Admins'
 PS C:\> $desc = New-DpapiNGDescriptor |
     Add-DpapiNGDescriptor -CurrentSid |
     Add-DpapiNGDescriptor -Sid $domainAdmins
@@ -91,6 +91,7 @@ PS C:\> ConvertTo-DpapiNGSecret secret -ProtectionDescriptor $desc
 ```
 
 Creates a DPAPI-NG secret that is protected by the current user when a `Domain Admins` member.
+The string value for `-Sid` here is automatically converted to the `System.Security.Principal.NTAccount` object and translated to the `SecurityIdentifier` string.
 
 ## PARAMETERS
 

--- a/docs/en-US/ConvertTo-DpapiNGSecret.md
+++ b/docs/en-US/ConvertTo-DpapiNGSecret.md
@@ -259,7 +259,7 @@ Accept wildcard characters: False
 ### -Sid
 Allows only the domain user or domain group specified by this SID to be able to decrypt the DPAPI-NG secret.
 If a group SID is specified, any user who is a member of that group can decrypt the secret it applies to.
-The value can either by a SecurityIdentifier string in the format `S-1-...` or as a [System.Security.Principal.NTAccount](https://learn.microsoft.com/en-us/dotnet/api/system.security.principal.ntaccount?view=net-8.0) object which will automatically be translated to a SID.
+The value can either by a SecurityIdentifier string in the format `S-1-...`, NTAccount string that will be translated to a `SecurityIdentifier` string, or as a [System.Security.Principal.NTAccount](https://learn.microsoft.com/en-us/dotnet/api/system.security.principal.ntaccount?view=net-8.0) object which will automatically be translated to a SID.
 
 Using a `SID` protection descriptor requires the host to be joined to a domain with a forest level of 2012 or newer.
 

--- a/docs/en-US/ConvertTo-DpapiNGSecret.md
+++ b/docs/en-US/ConvertTo-DpapiNGSecret.md
@@ -86,7 +86,7 @@ The same machine can decrypt the encrypted blob.
 
 ### Example 3 - Encrypt a secret for a specific domain group
 ```powershell
-PS C:\> $da = [System.Security.Principal.NTAccount]'DOMAIN\Domain Admins'
+PS C:\> $da = 'DOMAIN\Domain Admins'
 PS C:\> ConvertTo-DpapiNGSecret secret -Sid $da
 ```
 
@@ -95,7 +95,7 @@ Any other member of that group will be able to decrypt that secret.
 
 ### Example 4 - Encrypt a secret using a complex protection descriptor
 ```powershell
-PS C:\> $da = [System.Security.Principal.NTAccount]'DOMAIN\Domain Admins'
+PS C:\> $da = 'DOMAIN\Domain Admins'
 PS C:\> $desc = New-DpapiNGDescriptor |
     Add-DpapiNGDescriptor -CurrentSid |
     Add-DpapiNGDescriptor -Sid $da -Or

--- a/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptor.cs
+++ b/src/SecretManagement.DpapiNG.Module/DpapiNGDescriptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
@@ -88,7 +89,21 @@ public sealed class StringOrAccount
 
     public StringOrAccount(string value)
     {
-        Value = value;
+#pragma warning disable CA1416
+        // First check if it's a SID string value.
+        try
+        {
+            SecurityIdentifier sid = new(value);
+            Value = sid.Value;
+            return;
+        }
+        catch (ArgumentException)
+        {}
+
+        // If not try to translate the account name to a SID.
+        NTAccount account = new(value);
+        Value = account.Translate(typeof(SecurityIdentifier)).Value;
+#pragma warning restore CA1416
     }
 
 #if NET6_0_OR_GREATER

--- a/tests/DpapiNGDescriptor.Tests.ps1
+++ b/tests/DpapiNGDescriptor.Tests.ps1
@@ -26,6 +26,28 @@ Describe "*-DpapiNGDescriptor" {
         $actual.ToString() | Should -Be "SID=S-1-5-19"
     }
 
+    It "Adds sid from SID type" {
+        $actual = New-DpapiNGDescriptor | Add-DpapiNGDescriptor -Sid ([System.Security.Principal.SecurityIdentifier]::new("S-1-5-18"))
+        $actual.ToString() | Should -Be "SID=S-1-5-18"
+    }
+
+    It "Adds sid from NTAccount type" {
+        $actual = New-DpapiNGDescriptor | Add-DpapiNGDescriptor -Sid ([System.Security.Principal.NTAccount]::new("SYSTEM"))
+        $actual.ToString() | Should -Be "SID=S-1-5-18"
+    }
+
+    It "Adds sid from translated account string" {
+        $actual = New-DpapiNGDescriptor | Add-DpapiNGDescriptor -Sid SYSTEM
+        $actual.ToString() | Should -Be "SID=S-1-5-18"
+    }
+
+    It "Fails to translate unknown account string for SID" {
+        $err = {
+            New-DpapiNGDescriptor | Add-DpapiNGDescriptor -Sid invalid
+        } | Should -Throw -PassThru
+        [string]$err | Should -BeLike "Cannot bind parameter 'Sid'. Cannot convert value `"invalid`" to type `"StringOrAccount`". *"
+    }
+
     It "Adds current sid descriptor" {
         $actual = New-DpapiNGDescriptor | Add-DpapiNGDescriptor -CurrentSid
         $actual.ToString() | Should -Be "SID=$([System.Security.Principal.WindowsIdentity]::GetCurrent().User)"


### PR DESCRIPTION
Support automatically accepting an NTAccount or SecurityIdentifier string to translate to the SID string value on the -Sid parameters. This means the caller does not have to translate the NTAccount string value themselves or pass it as that typed object making it easier to call.

cc @davehope