### PR TITLE
Add DefaultProtectionDescriptor for registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.0 - TBD
 
 + Raised minimum PowerShell 7 versions to 7.4+
++ Added `DefaultProtectionDescriptor` as a `Register-SecretVault -VaultParameters` entry that is used as the default protection descriptor if not specified when creating a new secret.
 
 ## v0.4.0 - 2024-07-10
 

--- a/docs/en-US/about_DpapiNGSecretManagement.md
+++ b/docs/en-US/about_DpapiNGSecretManagement.md
@@ -37,6 +37,27 @@ Register-SecretVault @vaultParams
 This cmdlet will create a DPAPI-NG vault called `MyVault`, if no `Path` was specified in the `VaultParameters` a default path under `$env:LOCALAPPDATA\SecretManagement.DpapiNG\default.vault` is used as the path.
 If the vault file specified does not exist it will automatically be created when the vault operation is performed.
 It must be a the path to a file and the parent directory must already exist.
+
+It is also possible to set a default protection descriptor using the `DefaultProtectionDescriptor` vault parameter:
+
+```powershell
+$customDescriptor = New-DpapiNGDescriptor | Add-DpapiNGDescriptor -Local machine
+
+$vaultParams = @{
+    Name = 'MyVaultWithCustomDefaultProtectionDescriptor'
+    ModuleName = 'SecretManagement.DpapiNG'
+    VaultParameters = @{
+        Path = 'C:\path\to\vault_file'
+        DefaultProtectionDescriptor = $customDescriptor.ToString()
+    }
+}
+Register-SecretVault @vaultParams
+```
+
+When saving a secret to this vault it will use the `LOCAL=machine` protection descriptor by default for all secrets.
+If a custom protection descriptor is specified in the `-Metadata` then it will overwrite this default.
+The default descriptor used if none is set in the vault registration is `LOCAL=user`.
+
 Once the vault is registered it can referenced by the `-VaultName MyVault` parameter on the other `SecretManagement` cmdlets.
 It is possible to copy the vault file directory to other hosts as long as the secrets it contains is protected in a way that isn't tied to the same host.
 The file format of the vault uses [LiteDB](https://github.com/mbdavid/LiteDB) but this is an implementation detail and can change in the future.

--- a/src/SecretManagement.DpapiNG.Module/SetSecret.cs
+++ b/src/SecretManagement.DpapiNG.Module/SetSecret.cs
@@ -103,15 +103,27 @@ public sealed class SetSecretCommand : DpapiNGSecretBase
     private string ProcessMetadata(out string protectionDescriptor)
     {
         Hashtable localMetadata = (Hashtable)Metadata.Clone();
+
+        object? rawDescriptor = null;
         if (localMetadata.ContainsKey("ProtectionDescriptor"))
         {
-            protectionDescriptor = localMetadata["ProtectionDescriptor"]?.ToString() ?? "";
+            rawDescriptor = localMetadata["ProtectionDescriptor"];
+        }
+        else if (AdditionalParameters.ContainsKey("DefaultProtectionDescriptor"))
+        {
+            rawDescriptor = AdditionalParameters["DefaultProtectionDescriptor"];
+        }
+
+        if (rawDescriptor is not null)
+        {
+            protectionDescriptor = LanguagePrimitives.ConvertTo<string>(rawDescriptor);
         }
         else
         {
             protectionDescriptor = "LOCAL=user";
-            localMetadata["ProtectionDescriptor"] = protectionDescriptor;
         }
+
+        localMetadata["ProtectionDescriptor"] = protectionDescriptor;
 
         return PSSerializer.Serialize(localMetadata);
     }

--- a/src/SecretManagement.DpapiNG.Module/SetSecretInfo.cs
+++ b/src/SecretManagement.DpapiNG.Module/SetSecretInfo.cs
@@ -53,7 +53,7 @@ public sealed class SetSecretInfoCommand : DpapiNGSecretBase
                 {
                     string msg =
                         "It is not possible to change the ProtectionDescriptor for an existing set. Use " +
-                        "Set-SecretInfo to create a new secret instead.";
+                        "Set-Secret to create a new secret instead.";
                     ErrorRecord err = new(
                         new ArgumentException(msg),
                         "SecretManagement.DpapiNG.SetSecretInfoChangedDesc",


### PR DESCRIPTION
Adds the DefaultProtectionDescription for a vault registration parameters. This allows the vault to set a default descriptor to use for encryption without having to specify it for every Set-Secret call. Add DefaultProtectionDescriptor for registration.

Fixes: https://github.com/jborean93/SecretManagement.DpapiNG/issues/14